### PR TITLE
Change how default ddraw settings are set

### DIFF
--- a/ksetup.ps1
+++ b/ksetup.ps1
@@ -82,6 +82,7 @@ if ( $cwd -ceq 'Kohan Ahrimans Gift') {
         # Set cnc-ddraw default options
         $kag_section = @"
 ; Kohan: Ahriman's Gift
+[_ag]
 windowed=true
 fullscreen=true
 maintas=true

--- a/ksetup.ps1
+++ b/ksetup.ps1
@@ -1,4 +1,4 @@
-#!pwsh
+#!/usr/bin/env pwsh
 
 ##KSETUP.PS1
 # This is a little PowerShell script to install the required things
@@ -80,7 +80,14 @@ if ( $cwd -ceq 'Kohan Ahrimans Gift') {
         Remove-Item -Recurse "cnc-ddraw"
         Remove-Item $cncddrawFilename
         # Set cnc-ddraw default options
-        (get-content './ddraw.ini').Replace('windowed=false','windowed=true').Replace('fullscreen=false','fullscreen=true').Replace('maintas=false','maintas=true') | Set-Content './ddraw.ini'
+        $kag_section = @"
+; Kohan: Ahriman's Gift
+windowed=true
+fullscreen=true
+maintas=true
+"@
+        Add-Content './ddraw.ini' $kag_section
+
         $choice = Read-Host -Prompt "Open cnc-ddraw config tool? [y|N]"
         if ( $choice -eq "y" ) {
             & "./cnc-ddraw config.exe"


### PR DESCRIPTION
ddraw.ini now has a new section for Kohan added to it, rather than having all matching key/value pairs changed. This feels cleaner than clobbering all the existing settings in the file, including those set for other games