### PR TITLE
Fix khaldun.net filename and Invoke-WebRequest calls

### DIFF
--- a/ksetup.ps1
+++ b/ksetup.ps1
@@ -49,9 +49,11 @@ if (Test-Path '_ag.exe') {
     }
     try {
         # Download Kohan Gold
-        $target = "https://github.com/$kgTarget/releases/download/$kgLatest/$kgFilename"
-        Write-Output "Downloading KohanGold $kgLatest from $target"
-        Invoke-WebRequest -UseBasicParsing -OutFile $kgFilename $target
+        if (-Not (Test-Path "$kgFilename")) {
+            $target = "https://github.com/$kgTarget/releases/download/$kgLatest/$kgFilename"
+            Write-Output "Downloading KohanGold $kgLatest from $target"
+            Invoke-WebRequest -UseBasicParsing -OutFile $kgFilename $target
+        }
 
         # Download KohanLauncher.exe
         if (-Not (Test-Path 'KohanLauncher.exe')) {

--- a/ksetup.ps1
+++ b/ksetup.ps1
@@ -69,6 +69,7 @@ if (Test-Path '_ag.exe') {
         # Unzip OpenSpy Client
         Write-Output "Unpacking khaldun.net Client $tag"
         Expand-Archive -Force $openspyFilename
+        Move-Item -Force -Destination dinput.dll "dinput/dinput.dll"
         Write-Output "Cleaning up khaldun.net files"
         Remove-Item -Recurse "dinput/"
         Remove-Item $openspyFilename

--- a/ksetup.ps1
+++ b/ksetup.ps1
@@ -10,7 +10,7 @@ function Get-LatestTag {
         [string]$UserRepo
     )
     $target = "https://api.github.com/repos/$UserRepo/releases/latest"
-    $tag = (Invoke-WebRequest $target | ConvertFrom-Json).tag_name
+    $tag = (Invoke-WebRequest -UseBasicParsing $target | ConvertFrom-Json).tag_name
     Write-Output $tag
 }
 
@@ -34,7 +34,7 @@ $kgLatest = Get-LatestTag $kgTarget
 
 # Substring strips the leading v which is not used in the filename
 $kgFilename = "KohanGold-$($kgLatest.Substring(1)).tgx"
-$openspyFilename = 'openspy.zip'
+$openspyFilename = 'dinput.zip'
 $cncddrawFilename = 'cnc-ddraw.zip'
 
 $cwd = Split-Path -Path (Get-Location) -Leaf
@@ -51,32 +51,31 @@ if (Test-Path '_ag.exe') {
         # Download Kohan Gold
         $target = "https://github.com/$kgTarget/releases/download/$kgLatest/$kgFilename"
         Write-Output "Downloading KohanGold $kgLatest from $target"
-        Invoke-WebRequest -OutFile $kgFilename $target
+        Invoke-WebRequest -UseBasicParsing -OutFile $kgFilename $target
 
         # Download KohanLauncher.exe
         if (-Not (Test-Path 'KohanLauncher.exe')) {
             Write-Output "Downloading KohanLauncher"
-            Invoke-WebRequest -OutFile "KohanLauncher.exe" $launcherTarget
+            Invoke-WebRequest -UseBasicParsing -OutFile "KohanLauncher.exe" $launcherTarget
         }
 
         # Download OpenSpy Client
         $tag = Get-LatestTag $khaldunNetTarget
         $target = "https://github.com/$khaldunNetTarget/releases/download/$tag/$openspyFilename"
         Write-Output "Downloading khaldun.net client $tag from $target"
-        Invoke-WebRequest -OutFile $openspyFilename $target
+        Invoke-WebRequest -UseBasicParsing -OutFile $openspyFilename $target
         # Unzip OpenSpy Client
-        Write-Output "Unpacking OpenSpy Client $tag"
+        Write-Output "Unpacking khaldun.net Client $tag"
         Expand-Archive -Force $openspyFilename
-        Move-Item -Force -Destination dinput.dll "openspy/openspy.x86.dll"
-        Write-Output "Cleaning up OpenSpy files"
-        Remove-Item -Recurse "openspy/"
+        Write-Output "Cleaning up khaldun.net files"
+        Remove-Item -Recurse "dinput/"
         Remove-Item $openspyFilename
 
         # Download cnc-ddraw
         $tag = Get-LatestTag $cncddrawTarget
         $target = "https://github.com/$cncddrawTarget/releases/download/$tag/$cncddrawFilename"
         Write-Output "Downloading cnc-ddraw $tag from $target"
-        Invoke-WebRequest -OutFile $cncddrawFilename $target
+        Invoke-WebRequest -UseBasicParsing -OutFile $cncddrawFilename $target
         # Unzip cnc-ddraw
         Write-Output "Unpacking cnc-ddraw $tag"
         Expand-Archive -Force $cncddrawFilename


### PR DESCRIPTION
- Change the khaldunNetTarget variable to 'dinput.zip' so that it can be
  found correctly
- Update file paths in call to Move-Item for dinput.dll
- Update log messages to mention khaldun.net rather than OpenSpy
- Add the -UseBasicParsing flag to all Invoke-WebRequest calls, as
  without this it fails on some systems
- Check if the user already has the latest Kohan Gold version before
  attempting download